### PR TITLE
Fix keybindings and Neovim config organization

### DIFF
--- a/nvim/init.lua
+++ b/nvim/init.lua
@@ -3,6 +3,12 @@
 -------------------------------------------------------------------------------
 local vim = vim
 
+-- Make sure to setup `mapleader` and `maplocalleader` before
+-- loading lazy.nvim so that mappings are correct.
+vim.g.mapleader = " "
+vim.g.maplocalleader = "\\"
+
+
 require('config.general')                          -- General vim configurations
 require('config.remaps')                           -- Keymaps
 require('config.lazy')                             -- Load Lazy plugin manager

--- a/nvim/lua/config/general.lua
+++ b/nvim/lua/config/general.lua
@@ -2,11 +2,10 @@ local vim = vim
 
 vim.opt.guifont = "VictorMono Nerd Font:h20"                         -- Font
 
-vim.cmd('set number')
-
 ----------------------------------------------------------------
 -- General Settings
 ----------------------------------------------------------------
+vim.cmd('set number')
 vim.opt.backup = false                                               -- Do not backup
 vim.opt.colorcolumn = "120"                                          -- Long column indicator
 vim.opt.textwidth = 120                                              -- Text width

--- a/nvim/lua/config/lazy.lua
+++ b/nvim/lua/config/lazy.lua
@@ -15,12 +15,6 @@ if not (vim.uv or vim.loop).fs_stat(lazypath) then
 end
 vim.opt.rtp:prepend(lazypath)
 
--- Make sure to setup `mapleader` and `maplocalleader` before
--- loading lazy.nvim so that mappings are correct.
--- This is also a good place to setup other settings (vim.opt)
-vim.g.mapleader = " "
-vim.g.maplocalleader = "\\"
-
 -- Setup lazy.nvim
 require("lazy").setup({
   spec = {

--- a/nvim/lua/config/remaps.lua
+++ b/nvim/lua/config/remaps.lua
@@ -15,21 +15,27 @@ vim.keymap.set('n', 'gA', '<cmd>lua vim.lsp.buf.code_action()<CR>')
 vim.keymap.set('n', 'gF', '<cmd>lua vim.lsp.buf.formatting()<CR>')
 
 vim.keymap.set('n', '<leader>q', function()
-  -- closes the current buffer
-  -- if the current buffer is a neotree buffer, it will toggle the neotree
   local bufname = vim.api.nvim_buf_get_name(0)
   if bufname:match('neo%-tree') then
-    vim.cmd('Neotree toggle')
+    vim.cmd('Neotree close')
+    vim.cmd('bdelete')
   else
-    vim.cmd('bd')
+    vim.cmd('bdelete')
   end
-end, { desc = "Conditional buffer action for <leader>q" })
+end)
+
+vim.keymap.set('n', '<leader>Q', function()
+  local bufname = vim.api.nvim_buf_get_name(0)
+  if bufname:match('neo%-tree') then
+    vim.cmd('Neotree close')
+    vim.cmd('bdelete!')
+  else
+    vim.cmd('bdelete!')
+  end
+end)
 
 vim.keymap.set("n", "<leader>tt", ":Telescope<Cr>")                              -- Toggle telescope
 vim.keymap.set("v", "<leader>tt", ":Telescope<Cr>")                              -- Toggle telescope
-
-vim.keymap.set("n", "<leader>q", ":bw<Cr>")                                      -- Close buffer
-vim.keymap.set("n", "<leader>Q", ":bd!<Cr>")                                     -- Force close buffer
 
 vim.keymap.set("v", "<leader>y", "\"+y")                                         -- Copy to MacOS clipboard
 

--- a/nvim/lua/plugins/avante.lua
+++ b/nvim/lua/plugins/avante.lua
@@ -6,7 +6,7 @@ return {
     { "<leader>aa", "<Cmd>AvanteAsk<Cr>", mode = { "n", "v" } },        -- Open Avante Ask
     { "<leader>af", "<Cmd>AvanteFocus<Cr>", mode = { "n", "v" } },      -- Focus Avante
     { "<leader>as", "<Cmd>AvanteStop<Cr>", mode = { "n", "v" } },       -- Stop Avante
-    { "<leader>cc", "<Cmd>AvanteAsk Create a commit message from this diff with these restrictions: 1. Title must be 50 characters or less 2. Body must wrap at 72 characters 3. No author or co-author lines 4. Include a summary of changes<Cr>", mode = { "n" } }, -- Generate commit message
+    { "<leader>cc", "<Cmd>AvanteAsk Change this default commit message from this diff and replace it with a tailored commit message for the git diff with these restrictions: 1. Title must be 50 characters or less 2. Body must wrap at 72 characters 3. No author or co-author lines 4. Include a summary of changes<Cr>", mode = { "n" } }, -- Generate commit message
   },
   opts = {
     provider = "copilot",

--- a/nvim/lua/plugins/neotree.lua
+++ b/nvim/lua/plugins/neotree.lua
@@ -1,5 +1,6 @@
 return {
   "nvim-neo-tree/neo-tree.nvim",
+  lazy = false,
     dependencies = {
       { 'MunifTanjim/nui.nvim' },
       { 'nvim-lua/plenary.nvim' },


### PR DESCRIPTION
Moved leader key definitions to init.lua to ensure proper loading order. Fixed buffer close operations to handle Neotree windows correctly. Improved Avante commit message generation command. Made Neotree load eagerly instead of lazily.
Reorganized settings in general.lua for better grouping. Removed duplicate keymaps from remaps.lua.