### PR TITLE
feat: add comprehensive window settings for avante.nvim

### DIFF
--- a/nvim/lua/plugins/avante.lua
+++ b/nvim/lua/plugins/avante.lua
@@ -25,6 +25,32 @@ return {
     behaviour = {
       auto_suggestions = false, -- Experimental stage
     },
+    windows = {
+      ---@type "right" | "left" | "top" | "bottom"
+      position = "right", -- the position of the sidebar
+      wrap = true, -- similar to vim.o.wrap
+      width = 50, -- default % based on available width
+      sidebar_header = {
+        enabled = true, -- true, false to enable/disable the header
+        align = "center", -- left, center, right for title
+        rounded = true,
+      },
+      input = {
+        prefix = "> ",
+        height = 8, -- Height of the input window in vertical layout
+      },
+      edit = {
+        border = "rounded",
+        start_insert = true, -- Start insert mode when opening the edit window
+      },
+      ask = {
+        floating = false, -- Open the 'AvanteAsk' prompt in a floating window
+        start_insert = true, -- Start insert mode when opening the ask window
+        border = "rounded",
+        ---@type "ours" | "theirs"
+        focus_on_apply = "ours", -- which diff to focus after applying
+      },
+    },
   },
   -- if you want to build from source then do `make BUILD_FROM_SOURCE=true`
   build = "make",


### PR DESCRIPTION
- Added window configuration with sidebar position options
- Increased sidebar width to 50% for better content visibility
- Configured sidebar header with alignment and border settings
- Added input window height settings (8 lines) with customizable prefix
- Implemented edit window with rounded borders and auto-insert mode
- Added ask window settings with border and focus configuration
- Set wrap to true for improved text readability