### PR TITLE
feat(nvim): enable git-blame plugin with improved keymaps

### DIFF
--- a/nvim/lazy-lock.json
+++ b/nvim/lazy-lock.json
@@ -11,6 +11,7 @@
   "dressing.nvim": { "branch": "master", "commit": "2d7c2db2507fa3c4956142ee607431ddb2828639" },
   "friendly-snippets": { "branch": "main", "commit": "efff286dd74c22f731cdec26a70b46e5b203c619" },
   "fzf-lua": { "branch": "main", "commit": "47b85a25c0c0b2c20b4e75199ed01bb71e7814f5" },
+  "git-blame.nvim": { "branch": "master", "commit": "8503b199edf9a666fe7b1a989cf14e3c26b2eb03" },
   "github-nvim-theme": { "branch": "main", "commit": "c106c9472154d6b2c74b74565616b877ae8ed31d" },
   "gitsigns.nvim": { "branch": "main", "commit": "17ab794b6fce6fce768430ebc925347e349e1d60" },
   "img-clip.nvim": { "branch": "main", "commit": "08a02e14c8c0d42fa7a92c30a98fd04d6993b35d" },

--- a/nvim/lua/config/remaps.lua
+++ b/nvim/lua/config/remaps.lua
@@ -45,6 +45,7 @@ vim.keymap.set("v", "<S-UP>", ":m '<-2<CR>gv=gv")                               
 
 vim.keymap.set("n", "<C-x>1", "<C-w>o")                                          -- Close all other windows
 
+vim.keymap.set("n", "<leader>gt", ":GitBlameToggle<Cr>")                         -- ToggleBlame
 vim.keymap.set("n", "<leader>gy", ":GitBlameCopyFileURL<Cr>")                    -- Copy file URL to clipboard
 vim.keymap.set("v", "<leader>gy", ":GitBlameCopyFileURL<Cr>")                    -- Copy file URL to clipboard
-vim.keymap.set("n", "<leader>gc", ":GitBlameOpenCommitURL<Cr>")                  -- Open commit URL
+vim.keymap.set("v", "<leader>gY", ":GitBlameOpenFileURL<Cr>")                    -- Copy file URL to clipboard

--- a/nvim/lua/plugins/git.lua
+++ b/nvim/lua/plugins/git.lua
@@ -3,7 +3,18 @@
 --
 return {
   { 'tpope/vim-fugitive', lazy = false },      -- Git commands in nvim
---  { 'airblade/vim-gitgutter', lazy = false },  -- Show git signs on the left
+  --  { 'airblade/vim-gitgutter', lazy = false },  -- Show git signs on the left
   { 'lewis6991/gitsigns.nvim', lazy = false }, -- Show blame inline
-  -- { 'f-person/git-blame.nvim', lazy = false }, -- Show blame inline
+  {
+    "f-person/git-blame.nvim",
+    -- load the plugin at startup
+    event = "VeryLazy",
+    lazy = false,
+    opts = {
+      enabled = false,
+      message_template = "<<sha>> • <author> • <date>", -- template for the blame message, check the Message template section for more options
+      date_format = "%m-%d-%Y %H:%M:%S", -- template for the date, check Date format section for more options
+      virtual_text_column = 1,  -- virtual text start column, check Start virtual text at column section for more options
+    },
+  }
 }

--- a/nvim/lua/plugins/tiny_inline_diagnostic.lua
+++ b/nvim/lua/plugins/tiny_inline_diagnostic.lua
@@ -8,6 +8,7 @@ return {
         vim.diagnostic.config({ virtual_text = false }) -- Only if needed in your configuration, if you already have native LSP diagnostics
     end,
     opts = {
+      throttle = 5,
       multilines = {
         -- Enable multiline diagnostic messages
         enabled = true,


### PR DESCRIPTION
- Added git-blame.nvim plugin with custom formatting for blame info
- Enhanced Git keymaps with <leader>gt for blame toggle and <leader>gY for opening file URLs
- Added throttling (5ms) to inline diagnostics for better performance
- Removed unused GitBlameOpenCommitURL keymap