### PR TITLE
feat(nvim): add MacOS clipboard integration keymaps

### DIFF
--- a/nvim/lua/config/remaps.lua
+++ b/nvim/lua/config/remaps.lua
@@ -35,6 +35,10 @@ vim.keymap.set('n', '<leader>Q', function()
   end
 end)
 
+vim.keymap.set("v", "<D-c>", "\"+y")                                             -- Copy to MacOS clipboard
+vim.keymap.set("i", "<D-v>", "<Esc>k\"+p<Esc>i")                                  -- Paste from MacOS clipboard
+vim.keymap.set("n", "<D-v>", "k\"+p")                                             -- Paste from MacOS clipboard
+
 vim.keymap.set("n", "<leader>tt", ":Telescope<Cr>")                              -- Toggle telescope
 vim.keymap.set("v", "<leader>tt", ":Telescope<Cr>")                              -- Toggle telescope
 


### PR DESCRIPTION
* Added visual mode mapping for CMD+C to copy to system clipboard
* Added insert mode mapping for CMD+V to paste from system clipboard
* Added normal mode mapping for CMD+V to paste from system clipboard
* All mappings use the "+ register to interact with the system clipboard